### PR TITLE
NUI-714 add step installing plugin with aio and running tests from there

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,6 +92,12 @@ describe("integration tests", function() {
             shell(`
                 aio app test
             `);
+
+            // test as aio plugin
+            shell(`
+                aio plugins:install @adobe/aio-cli-plugin-asset-compute
+                aio asset-compute test-worker
+            `);
         }
     }).timeout(600000);
 });


### PR DESCRIPTION
For [NUI-714](https://jira.corp.adobe.com/browse/NUI-714).

This somewhat tests https://github.com/adobe/aio-cli-plugin-asset-compute/pull/34. It checks if the test-worker command can be successfully run via `aio`. (It does not check the output and whether it used the devDependency version, that would be quite complex. That's why the test here already succeeds even without the other PR released.