### PR TITLE
fix failing tests, aio lists generic worker first now

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -75,7 +75,7 @@ describe("integration tests", function() {
             const wait = "ping -n 5 127.0.0.1 >NUL";
             // this line must be exactly like this, including spaces or missing spaces (echo in windows CMD is tricky)
             shell(`
-                echo.>newline& (${wait} & echo a & ${wait} & echo& ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
+                echo.>newline& (${wait} & echo a & ${wait} & echo.& ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
             `);
         } else {
             shell(`

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -79,7 +79,7 @@ describe("integration tests", function() {
             `);
         } else {
             shell(`
-                (sleep 2; echo "a "; sleep 2; echo "aa "; sleep 2; echo) | aio app init --no-login -i ../../test/console.json
+                (sleep 2; echo "a "; sleep 2; sleep 2; echo) | aio app init --no-login -i ../../test/console.json
             `);
         }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -75,7 +75,7 @@ describe("integration tests", function() {
             const wait = "ping -n 5 127.0.0.1 >NUL";
             // this line must be exactly like this, including spaces or missing spaces (echo in windows CMD is tricky)
             shell(`
-                echo.>newline& (${wait} & echo a & ${wait} & echo & ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
+                echo.>newline& (${wait} & echo a & ${wait} & echo& ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
             `);
         } else {
             shell(`

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -75,7 +75,7 @@ describe("integration tests", function() {
             const wait = "ping -n 5 127.0.0.1 >NUL";
             // this line must be exactly like this, including spaces or missing spaces (echo in windows CMD is tricky)
             shell(`
-                echo.>newline& (${wait} & echo a & ${wait} & echo.& ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
+                echo.>newline& (${wait} & echo a & ${wait} & type newline& ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
             `);
         } else {
             shell(`

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -75,11 +75,11 @@ describe("integration tests", function() {
             const wait = "ping -n 5 127.0.0.1 >NUL";
             // this line must be exactly like this, including spaces or missing spaces (echo in windows CMD is tricky)
             shell(`
-                echo.>newline& (${wait} & echo a & ${wait} & echo aa & ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
+                echo.>newline& (${wait} & echo a & ${wait} & echo & ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
             `);
         } else {
             shell(`
-                (sleep 2; echo "a "; sleep 2; sleep 2; echo) | aio app init --no-login -i ../../test/console.json
+                (sleep 2; echo "a "; sleep 2; echo; sleep 2; echo) | aio app init --no-login -i ../../test/console.json
             `);
         }
 


### PR DESCRIPTION
## Description

There was a minor change in the aio cli causing these tests to fail. In choosing the app option, “Generic” is now listed first instead of `Adobe Asset compute worker` _and_ asset compute worker comes already checked off: https://travis-ci.com/github/adobe/asset-compute-integration-tests/jobs/400494611#L353 so the prompt incorrectly additionally chooses "generic". 

Below is an example of what the prompt looks like by default now:
<img width="783" alt="Screen Shot 2020-10-16 at 9 50 36 AM" src="https://user-images.githubusercontent.com/20048485/96286317-0dbd8500-0f95-11eb-8e75-710d6a6db936.png">


Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
