### PR TITLE
remove node 14 from travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ language: node_js
 node_js:
 - '10'
 - '12'
-- '14'
 os:
 - linux
 - windows


### PR DESCRIPTION
## Description

we keep seeing errors for linux + node 14 installing aio app plugins since `aio-lib-runtime` node version got pinned to 10 or 12: https://github.com/adobe/aio-lib-runtime/blob/master/package.json#L56

failing test: https://travis-ci.com/github/adobe/asset-compute-integration-tests/jobs/403569170

Although it is only failing on linux, the easiest solution is just to remove `node 14` from both windows & linux builds since its not supported by the aio cli.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
