### PR TITLE
Travis CI: add sizewatcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ notifications:
 
 
 after_script:
-  - npx @adobe/sizewatcher
+  - DEBUG=sizewatcher npx @adobe/sizewatcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,6 @@ notifications:
     template:
       - "3rd party developer integration tests %{result}\n\nBuild <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of <https://github.com/adobe/asset-compute-integration-tests|adobe/asset-compute-integration-tests> took %{duration}"
 
+
+after_script:
+  - npx @adobe/sizewatcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ notifications:
 
 
 after_script:
-  - DEBUG=sizewatcher npx @adobe/sizewatcher
+  - npx @adobe/sizewatcher


### PR DESCRIPTION
This updates the travis CI jobs to run [@adobe/sizewatcher](https://github.com/adobe/sizewatcher).

This tool warns if pull requests introduce large size increases (e.g. npm modules dependencies, package size etc.).