### PR TITLE
NUI-912 check output of aio app test

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,7 +92,7 @@ describe("integration tests", function() {
             const testLogsFile = path.join("build", "test-results", "test-worker", "test.log");
             assert.ok(!fs.existsSync(testLogsFile));
             shell(`
-            aio app test
+               aio app test
             `);
             assert.ok(fs.existsSync(testLogsFile));
             const testLogs = fs.readFileSync(testLogsFile);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,11 +89,14 @@ describe("integration tests", function() {
             console.log("SKIPPING aio app test on Travis Windows (docker linux containers required for worker tests)");
 
         } else {
-            const out = shell(`
+            const testLogsFile = path.join("build", "test-results", "test-worker", "test.log");
+            assert(!fs.existsSync(testLogsFile));
+            shell(`
             aio app test
             `);
-            assert.ok(out && out.includes("- corrupt-input"));
-            assert.ok(out && out.includes("✔ Succeeded (expected error)"));
+            assert(fs.existsSync(testLogsFile));
+            // assert.ok(out && out.includes("- corrupt-input"));
+            // assert.ok(out && out.includes("✔ Succeeded (expected error)"));
 
             // test as aio plugin
             shell(`

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,7 +92,7 @@ describe("integration tests", function() {
             const testLogsFile = path.join("build", "test-results", "test-worker", "test.log");
             assert.ok(!fs.existsSync(testLogsFile));
             shell(`
-               aio app test
+                aio app test
             `);
             assert.ok(fs.existsSync(testLogsFile));
             const testLogs = fs.readFileSync(testLogsFile);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,7 +27,7 @@ function shell(cmd, dir) {
         .filter(line => !line.startsWith("#"))
         .join(os.platform() === "win32" ? " & " : "; ");
 
-    return execSync(cmd, {cwd: dir, stdio: 'inherit'});
+    execSync(cmd, {cwd: dir, stdio: 'inherit'});
 }
 
 // create dir (if doesn't exist yet) and change into it
@@ -97,7 +97,7 @@ describe("integration tests", function() {
             assert.ok(fs.existsSync(testLogsFile));
             const testLogs = fs.readFileSync(testLogsFile);
             assert.ok(testLogs.includes('Validation successful'));
-            
+
             // test as aio plugin
             shell(`
                 aio plugins:install @adobe/aio-cli-plugin-asset-compute

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,7 +27,7 @@ function shell(cmd, dir) {
         .filter(line => !line.startsWith("#"))
         .join(os.platform() === "win32" ? " & " : "; ");
 
-    execSync(cmd, {cwd: dir, stdio: 'inherit'});
+    return execSync(cmd, {cwd: dir, stdio: 'inherit'});
 }
 
 // create dir (if doesn't exist yet) and change into it

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -90,14 +90,14 @@ describe("integration tests", function() {
 
         } else {
             const testLogsFile = path.join("build", "test-results", "test-worker", "test.log");
-            assert(!fs.existsSync(testLogsFile));
+            assert.ok(!fs.existsSync(testLogsFile));
             shell(`
             aio app test
             `);
-            assert(fs.existsSync(testLogsFile));
-            // assert.ok(out && out.includes("- corrupt-input"));
-            // assert.ok(out && out.includes("✔ Succeeded (expected error)"));
-
+            assert.ok(fs.existsSync(testLogsFile));
+            const testLogs = fs.readFileSync(testLogsFile);
+            assert.ok(testLogs.includes('Validation successful'));
+            
             // test as aio plugin
             shell(`
                 aio plugins:install @adobe/aio-cli-plugin-asset-compute

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,9 +89,11 @@ describe("integration tests", function() {
             console.log("SKIPPING aio app test on Travis Windows (docker linux containers required for worker tests)");
 
         } else {
-            shell(`
-                aio app test
+            const out = shell(`
+            aio app test
             `);
+            assert.ok(out && out.includes("- corrupt-input"));
+            assert.ok(out && out.includes("✔ Succeeded (expected error)"));
 
             // test as aio plugin
             shell(`


### PR DESCRIPTION
## Description

`aio app test` got fixed in the most recent release: 
`@adobe/aio-cli-plugin-app@5.1.1`
https://cq-dev.slack.com/archives/CE6GQG81F/p1604980956292000

To catch this ourselves, we can check the output of the test logs to make sure they include our nui tests were run and successful. The output of [`execSync`](https://github.com/adobe/asset-compute-integration-tests/pull/11/files#diff-af95cb6f5f65fe70216ddce70325e785438d5aaff956a0666ebf46ef6402f526L30) did not include anything so I could not use the method described in the ticket. I even tried mocking [stdout](https://www.npmjs.com/package/stdout-stderr) using the npm library but that also did not work. So I settled on looking at the log files.

Fixes # https://jira.corp.adobe.com/browse/NUI-912

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
