### PR TITLE
NUI-1057 add slack integrations to github actions in asset-compute-integration-tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,12 +27,12 @@ jobs:
     - run: npm ci
     - run: npm test
 
-  slack-notify:
-
+  slack-notify-success:
+    needs: [build]
     runs-on: ubuntu-latest
+    if: success()
     steps:
     - name: Notify slack success
-      if: success()
       env:
         SLACK_BOT_TOKEN: ${{ secrets.ASSET_COMPUTE_IT_SLACK_BOT_TOKEN }}
       uses: voxmedia/github-action-slack-notify-build@v1
@@ -40,8 +40,13 @@ jobs:
         channel_id: GAMJLHSBH
         status: SUCCESS
         color: good
+        
+  slack-notify-failure:
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
     - name: Notify slack fail
-      if: failure()
       env:
         SLACK_BOT_TOKEN: ${{ secrets.ASSET_COMPUTE_IT_SLACK_BOT_TOKEN }}
       uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron:  '30 17 * * *'
+    - cron:  '0 1 * * *'
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,8 +24,13 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm test
+  
+  notify-slack-success:
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+    - uses: actions/checkout@v2
     - name: Notify slack success
-      if: success()
       env:
         SLACK_BOT_TOKEN: ${{ secrets.ASSET_COMPUTE_IT_SLACK_BOT_TOKEN }}
       uses: voxmedia/github-action-slack-notify-build@v1
@@ -33,13 +38,16 @@ jobs:
         channel_id: GAMJLHSBH
         status: SUCCESS
         color: good
-
-    - name: Notify slack fail
-      if: failure()
+  notify-slack-failure:
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+    - uses: actions/checkout@v2
+    - name: Notify slack success
       env:
         SLACK_BOT_TOKEN: ${{ secrets.ASSET_COMPUTE_IT_SLACK_BOT_TOKEN }}
       uses: voxmedia/github-action-slack-notify-build@v1
       with:
         channel_id: GAMJLHSBH
-        status: FAILED
-        color: danger
+        status: SUCCESS
+        color: good

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,13 +24,9 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm test
-  
-  notify-slack-success:
-    runs-on: ubuntu-latest
-    if: success()
-    steps:
-    - uses: actions/checkout@v2
+
     - name: Notify slack success
+      if: success()
       env:
         SLACK_BOT_TOKEN: ${{ secrets.ASSET_COMPUTE_IT_SLACK_BOT_TOKEN }}
       uses: voxmedia/github-action-slack-notify-build@v1
@@ -38,16 +34,13 @@ jobs:
         channel_id: GAMJLHSBH
         status: SUCCESS
         color: good
-  notify-slack-failure:
-    runs-on: ubuntu-latest
-    if: failure()
-    steps:
-    - uses: actions/checkout@v2
-    - name: Notify slack success
+
+    - name: Notify slack fail
+      if: failure()
       env:
         SLACK_BOT_TOKEN: ${{ secrets.ASSET_COMPUTE_IT_SLACK_BOT_TOKEN }}
       uses: voxmedia/github-action-slack-notify-build@v1
       with:
         channel_id: GAMJLHSBH
-        status: SUCCESS
-        color: good
+        status: FAILED
+        color: danger

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,7 +30,7 @@ jobs:
         SLACK_BOT_TOKEN: ${{ secrets.ASSET_COMPUTE_IT_SLACK_BOT_TOKEN }}
       uses: voxmedia/github-action-slack-notify-build@v1
       with:
-        channel: app-alerts
+        channel_id: GAMJLHSBH
         status: SUCCESS
         color: good
 
@@ -40,6 +40,6 @@ jobs:
         SLACK_BOT_TOKEN: ${{ secrets.ASSET_COMPUTE_IT_SLACK_BOT_TOKEN }}
       uses: voxmedia/github-action-slack-notify-build@v1
       with:
-        channel: app-alerts
+        channel_id: GAMJLHSBH
         status: FAILED
         color: danger

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron:  '30 17 * * *'
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.16, 10.19, 12.16, 12.19]
+        node-version: [12.19]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.16, 12.19]
+        node-version: [10.16, 10.19, 12.16, 12.19]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,3 +24,22 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm test
+    - name: Notify slack success
+      if: success()
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.ASSET_COMPUTE_IT_SLACK_BOT_TOKEN }}
+      uses: voxmedia/github-action-slack-notify-build@v1
+      with:
+        channel: app-alerts
+        status: SUCCESS
+        color: good
+
+    - name: Notify slack fail
+      if: failure()
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.ASSET_COMPUTE_IT_SLACK_BOT_TOKEN }}
+      uses: voxmedia/github-action-slack-notify-build@v1
+      with:
+        channel: app-alerts
+        status: FAILED
+        color: danger

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.19]
+        node-version: [12.16, 12.19]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -27,6 +27,10 @@ jobs:
     - run: npm ci
     - run: npm test
 
+  slack-notify:
+
+    runs-on: ubuntu-latest
+    steps:
     - name: Notify slack success
       if: success()
       env:
@@ -36,7 +40,6 @@ jobs:
         channel_id: GAMJLHSBH
         status: SUCCESS
         color: good
-
     - name: Notify slack fail
       if: failure()
       env:


### PR DESCRIPTION
## Description
uses this github action: https://github.com/marketplace/actions/slack-notify-build
- created slack app: `Asset Compute Github Action`
- run slack app on failures and successes
- schedule job to run once a day at 1:00 UTC (6pm): https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events


Fixes # https://jira.corp.adobe.com/browse/NUI-1057

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
