### PR TITLE
NUI-1501 change prompts to fit aio-cli v8

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -80,12 +80,15 @@ describe("integration tests", function() {
                 echo.>newline& (${wait} & echo a & ${wait} & type newline& ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
             `);
         } else {
+            // shell(`
+            //     (sleep 2; echo "a "; sleep 2; echo; sleep 2; echo; echo; sleep 3;) | aio app init --no-login -i ../../test/console.json
+            // `);
             shell(`
-                (sleep 2; echo "a "; sleep 2; echo; sleep 2; echo; echo; sleep 3;) | aio app init --no-login -i ../../test/console.json
+                (sleep 2; echo " i"; sleep 2; echo;) | aio app init --no-login -i ../../test/console.json
             `);
         }
         shell('ls');
-        assert(fs.existsSync(path.join("actions", "worker", "index.js")));
+        assert(fs.existsSync(path.join("src", "dx-asset-compute-worker-1", "actions", "worker", "index.js")));
 
         if (process.env.TRAVIS && os.platform() === "win32") {
             console.log("SKIPPING aio app test on Travis Windows (docker linux containers required for worker tests)");

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -81,10 +81,10 @@ describe("integration tests", function() {
             `);
         } else {
             shell(`
-                (sleep 2; echo "a "; sleep 2; echo; sleep 2; echo) | aio app init --no-login -i ../../test/console.json
+                (sleep 2; echo "a "; sleep 2; echo; sleep 2; echo; echo; sleep 3;) | aio app init --no-login -i ../../test/console.json
             `);
         }
-
+        shell('ls');
         assert(fs.existsSync(path.join("actions", "worker", "index.js")));
 
         if (process.env.TRAVIS && os.platform() === "win32") {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -61,7 +61,7 @@ describe("integration tests", function() {
         cd(BUILD_DIR);
     });
 
-    it("should install tools and run developer experience", async function() {
+    it("should install lastest version of tools and run developer experience", async function() {
         shell(`
             npm install -g @adobe/aio-cli
             aio update --no-confirm
@@ -80,15 +80,58 @@ describe("integration tests", function() {
                 echo.>newline& (${wait} & echo a & ${wait} & type newline& ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
             `);
         } else {
-            // shell(`
-            //     (sleep 2; echo "a "; sleep 2; echo; sleep 2; echo; echo; sleep 3;) | aio app init --no-login -i ../../test/console.json
-            // `);
             shell(`
                 (sleep 2; echo " i"; sleep 2; echo;) | aio app init --no-login -i ../../test/console.json
             `);
         }
         shell('ls');
         assert(fs.existsSync(path.join("src", "dx-asset-compute-worker-1", "actions", "worker", "index.js")));
+
+        if (process.env.TRAVIS && os.platform() === "win32") {
+            console.log("SKIPPING aio app test on Travis Windows (docker linux containers required for worker tests)");
+
+        } else {
+            const testLogsFile = path.join("build", "test-results", "test-worker", "test.log");
+            assert.ok(!fs.existsSync(testLogsFile));
+            shell(`
+                aio app test
+            `);
+            assert.ok(fs.existsSync(testLogsFile));
+            const testLogs = fs.readFileSync(testLogsFile);
+            assert.ok(testLogs.includes('Validation successful'));
+
+            // test as aio plugin
+            shell(`
+                aio plugins:install @adobe/aio-cli-plugin-asset-compute
+                aio asset-compute test-worker
+            `);
+        }
+    }).timeout(600000);
+    it("should install version 7.1.0 of aio-cli and run developer experience", async function() {
+        shell(`
+        npm install -g @adobe/aio-cli@7.1.0
+        aio update --no-confirm
+        aio info
+    `);
+
+        cd("project");
+
+        // HACK: since `aio app init` has no way to programmatically select from the different questions,
+        //       we have to simulate user input using echo and piping to stdin, which is different between windows & *nix
+        if (os.platform() === "win32") {
+            // const timeout = "%SystemRoot%\\System32\\timeout.exe";
+            const wait = "ping -n 5 127.0.0.1 >NUL";
+            // this line must be exactly like this, including spaces or missing spaces (echo in windows CMD is tricky)
+            shell(`
+                echo.>newline& (${wait} & echo a & ${wait} & type newline& ${wait} & type newline) | aio app init --no-login  -i ..\\..\\test\\console.json
+            `);
+        } else {
+            shell(`
+                (sleep 2; echo "a "; sleep 2; echo; sleep 2; echo) | aio app init --no-login -i ../../test/console.json
+            `);
+        }
+
+        assert(fs.existsSync(path.join("actions", "worker", "index.js")));
 
         if (process.env.TRAVIS && os.platform() === "win32") {
             console.log("SKIPPING aio app test on Travis Windows (docker linux containers required for worker tests)");


### PR DESCRIPTION
## Description

aio-cli v8 brought in breaking changes. 
For it work, it required changes in aio-cli-plugin-asset-compute: https://github.com/adobe/aio-cli-plugin-asset-compute/pull/66
and the generator: https://github.com/adobe/generator-aio-app/pull/162, https://github.com/adobe/generator-aio-app/pull/158

also, still run `aio-cli` v7.1.0 to keep a stable version check each day


Fixes # https://jira.corp.adobe.com/browse/NUI-1501

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
