### PR TITLE
fix: add/run tests for the latest version of the aio-cli

### DIFF
--- a/test/cli-next.test.js
+++ b/test/cli-next.test.js
@@ -29,7 +29,7 @@ function shell(cmd, dir) {
 }
 
 // skip for now until the new way of testing the next aio-cli version is ready
-it.skip("should install (next) version of aio-cli and run developer experience", async function() {
+it("should install (next) version of aio-cli and run developer experience", async function() {
 
     shell(`
         npm install --no-save @adobe/aio-cli-next

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,4 +88,32 @@ describe("integration tests", function() {
             aio asset-compute test-worker
         `);
     }).timeout(600000);
+
+    it("should install latest version of tools and run developer experience", async function() {
+        shell(`
+            npm install -g @adobe/aio-cli@latest
+            aio info
+        `);
+
+        cd("project");
+
+        shell(`aio app:init --no-login -i ../../test/console.json -t @adobe/generator-app-asset-compute@1.0.2`);
+        shell('ls');
+        assert(fs.existsSync(path.join("src", "dx-asset-compute-worker-1", "actions", "worker", "index.js")));
+
+        const testLogsFile = path.join("build", "test-results", "test-worker", "test.log");
+        assert.ok(!fs.existsSync(testLogsFile));
+        shell(`
+            aio app test
+        `);
+        assert.ok(fs.existsSync(testLogsFile));
+        const testLogs = fs.readFileSync(testLogsFile);
+        assert.ok(testLogs.includes('Validation successful'));
+
+        // test as aio plugin
+        shell(`
+            aio plugins:install @adobe/aio-cli-plugin-asset-compute
+            aio asset-compute test-worker
+        `);
+    }).timeout(600000);
 });

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -28,9 +28,9 @@ function shell(cmd, dir) {
     execSync(cmd, {cwd: dir, stdio: 'inherit'});
 }
 
-it.skip("should install (local) version of aio-cli and run developer experience", async function() {
+it("should install (local) version of aio-cli and run developer experience", async function() {
     shell(`
-        npm install --no-save @adobe/aio-cli
+        npm install --no-save @adobe/aio-cli@latest
         npx aio info
         mkdir project
         cd project


### PR DESCRIPTION
## Description

Adds support for testing the latest aio-cli.
Requires https://github.com/adobe/aio-cli-plugin-asset-compute/pull/109 and a new release of the asset-compute plugin before the aio-next test passes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
